### PR TITLE
#4 kuji_logic

### DIFF
--- a/packages/backend/src/services/dynamodb.ts
+++ b/packages/backend/src/services/dynamodb.ts
@@ -99,10 +99,12 @@ export async function getItem<T = Record<string, unknown>>(
 
 export async function putItem(
   item: Record<string, unknown>,
+  conditionExpression?: string,
 ): Promise<void> {
   const params: PutCommandInput = {
     TableName: TABLE_NAME,
     Item: item,
+    ...(conditionExpression && { ConditionExpression: conditionExpression }),
   };
   await ddbDoc.send(new PutCommand(params));
 }
@@ -134,6 +136,7 @@ export async function updateItem(
   updateExpression: string,
   expressionAttributeValues: Record<string, unknown>,
   expressionAttributeNames?: Record<string, string>,
+  conditionExpression?: string,
 ): Promise<Record<string, unknown> | undefined> {
   const params: UpdateCommandInput = {
     TableName: TABLE_NAME,
@@ -142,6 +145,7 @@ export async function updateItem(
     ExpressionAttributeValues: expressionAttributeValues,
     ReturnValues: 'ALL_NEW',
     ...(expressionAttributeNames && { ExpressionAttributeNames: expressionAttributeNames }),
+    ...(conditionExpression && { ConditionExpression: conditionExpression }),
   };
   const result = await ddbDoc.send(new UpdateCommand(params));
   return result.Attributes;

--- a/packages/backend/src/services/lottery.ts
+++ b/packages/backend/src/services/lottery.ts
@@ -1,3 +1,4 @@
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
 import {
   ENTITY_PREFIXES,
   GSI,
@@ -107,63 +108,92 @@ export async function runLottery(): Promise<{ processed: number; winners: number
     let seriesWinners = 0;
     let seriesLosers = 0;
 
-    // 4. Update data for each reservation
+    // 4. Update kuji series remaining tickets FIRST (optimistic lock)
+    // This acts as a concurrency gate: only one Lambda execution can succeed.
+    // If another execution already updated remainingTickets, ConditionalCheckFailedException
+    // is thrown and we skip this series entirely, preventing double-issuance.
+    const newRemainingTickets = Math.max(0, remainingTickets - totalDrawn);
+    const seriesKeys = keys.kujiSeries(storeId, seriesId);
+    const newStatus = newRemainingTickets <= 0 ? 'sold_out' : 'on_sale';
+
+    try {
+      await updateItem(
+        { PK: seriesKeys.PK, SK: seriesKeys.SK },
+        'SET remainingTickets = :remaining, #st = :status, updatedAt = :now',
+        {
+          ':remaining': newRemainingTickets,
+          ':status': newStatus,
+          ':now': now,
+          ':oldRemaining': remainingTickets,
+        },
+        { '#st': 'status' },
+        'remainingTickets = :oldRemaining',
+      );
+    } catch (err: unknown) {
+      if (err instanceof ConditionalCheckFailedException) {
+        console.warn(`Skipping series ${seriesId} at store ${storeId}: remainingTickets changed (concurrent execution detected).`);
+        continue;
+      }
+      throw err;
+    }
+
+    // 5. Update individual reservations and send notifications
+    // The series update above succeeded, so we can safely record results.
     for (const reservation of pendingReservations) {
       const userId = reservation.userId;
       const drawsWon = winCounts.get(userId) || 0;
       const resultStatus: 'won' | 'lost' = drawsWon > 0 ? 'won' : 'lost';
 
-      // Update reservation status
-      const resKeys = keys.reservation(storeId, seriesId, userId);
-      await updateItem(
-        { PK: resKeys.PK, SK: resKeys.SK },
-        'SET #st = :status, updatedAt = :now',
-        { ':status': resultStatus, ':now': now },
-        { '#st': 'status' },
-      );
+      try {
+        // Update reservation status
+        const resKeys = keys.reservation(storeId, seriesId, userId);
+        await updateItem(
+          { PK: resKeys.PK, SK: resKeys.SK },
+          'SET #st = :status, updatedAt = :now',
+          { ':status': resultStatus, ':now': now },
+          { '#st': 'status' },
+        );
 
-      // Write lottery result
-      const lotteryKeys = keys.lotteryResult(storeId, seriesId, today, userId);
-      const lotteryResult: LotteryResult & Record<string, unknown> = {
-        ...lotteryKeys,
-        storeId,
-        seriesId,
-        userId,
-        date: today,
-        result: resultStatus,
-        drawsWon,
-      };
-      await putItem(lotteryResult);
+        // Write lottery result (idempotent: skip if already written)
+        const lotteryKeys = keys.lotteryResult(storeId, seriesId, today, userId);
+        const lotteryResult: LotteryResult & Record<string, unknown> = {
+          ...lotteryKeys,
+          storeId,
+          seriesId,
+          userId,
+          date: today,
+          result: resultStatus,
+          drawsWon,
+        };
+        await putItem(lotteryResult, 'attribute_not_exists(PK)');
 
-      // Send notification
-      const notificationMessage: LotteryResultMessage = {
-        type: 'lottery_result',
-        userId,
-        storeId,
-        seriesId,
-        seriesTitle: series.title,
-        result: resultStatus,
-        drawsWon,
-      };
-      await sendNotification(notificationMessage);
+        // Send notification
+        const notificationMessage: LotteryResultMessage = {
+          type: 'lottery_result',
+          userId,
+          storeId,
+          seriesId,
+          seriesTitle: series.title,
+          result: resultStatus,
+          drawsWon,
+        };
+        await sendNotification(notificationMessage);
 
-      if (resultStatus === 'won') {
-        seriesWinners++;
-      } else {
-        seriesLosers++;
+        if (resultStatus === 'won') {
+          seriesWinners++;
+        } else {
+          seriesLosers++;
+        }
+      } catch (reservationErr: unknown) {
+        if (reservationErr instanceof ConditionalCheckFailedException) {
+          // LotteryResult already exists — this user was processed in a previous run.
+          if (resultStatus === 'won') seriesWinners++;
+          else seriesLosers++;
+        } else {
+          console.error(`Failed to process reservation: userId=${userId} seriesId=${seriesId} storeId=${storeId}`, reservationErr);
+        }
       }
     }
-
-    // Update kuji series remaining tickets
-    const newRemainingTickets = Math.max(0, remainingTickets - totalDrawn);
-    const seriesKeys = keys.kujiSeries(storeId, seriesId);
-    const newStatus = newRemainingTickets <= 0 ? 'sold_out' : 'on_sale';
-    await updateItem(
-      { PK: seriesKeys.PK, SK: seriesKeys.SK },
-      'SET remainingTickets = :remaining, #st = :status, updatedAt = :now',
-      { ':remaining': newRemainingTickets, ':status': newStatus, ':now': now },
-      { '#st': 'status' },
-    );
 
     totalWinners += seriesWinners;
     totalLosers += seriesLosers;


### PR DESCRIPTION
1. 抽選単位の変更: 各予約の drawCount 分だけユーザーIDを lotteryPool
      配列に追加し、くじ1枚単位で抽選を行うようにしました。
   2. 完全ランダム化: lotteryPool 全体を Fisher-Yates
      アルゴリズムでシャッフルし、予約日時に依存しない抽選を実現しました。
   3. 当選者決定:
      シャッフル後の配列の先頭から、在庫数（remainingTickets）を上限として要素（
      当選くじ）を取り出します。
   4. データ更新:
       * 各ユーザーの当選枚数を集計。
       * 当選枚数が1枚以上ならステータスを won、0枚なら lost に設定。
       * LotteryResult に実際の当選枚数（drawsWon）を記録。
   5. 既存処理の維持:
      DynamoDBへの保存や通知送信の仕組みをそのまま活かしています。

